### PR TITLE
Make slicectrl restart & slice-update ssh (and ansible)-friendly

### DIFF
--- a/slicebase/bin/slice-update
+++ b/slicebase/bin/slice-update
@@ -1,9 +1,14 @@
 #!/bin/bash
 
 if [ -e /vsys/slice_update.out ] ; then
-    cat /vsys/slice_update.out &
+    cat /vsys/slice_update.out &> /dev/null & disown
     echo "1" > /vsys/slice_update.in
 else
-    echo "Error: /vsys/slice_update.out missing."
+    if [[ $EUID -ne 0 ]] ; then
+        echo "Error: please run slice-update as root."
+        exit 1
+    fi
+    echo "Error: /vsys/slice_update.out appears to be missing."
     echo "Please report this to support@measurementlab.net"
+    exit 1
 fi

--- a/slicebase/bin/slice-update
+++ b/slicebase/bin/slice-update
@@ -1,13 +1,14 @@
 #!/bin/bash
 
+if [[ $EUID -ne 0 ]] ; then
+    echo "Error: please run slice-update as root."
+    exit 1
+fi
+
 if [ -e /vsys/slice_update.out ] ; then
     cat /vsys/slice_update.out &> /dev/null & disown
     echo "1" > /vsys/slice_update.in
 else
-    if [[ $EUID -ne 0 ]] ; then
-        echo "Error: please run slice-update as root."
-        exit 1
-    fi
     echo "Error: /vsys/slice_update.out appears to be missing."
     echo "Please report this to support@measurementlab.net"
     exit 1

--- a/slicebase/etc/mlab/slicectrl-functions
+++ b/slicebase/etc/mlab/slicectrl-functions
@@ -50,9 +50,10 @@ function kill_remaining () {
     if [ -f /var/run/$SLICENAME/pids.beforestart ] ; then
         for pid in `comm -23 <( sort /var/run/$SLICENAME/pids.afterstop ) \
                              <( sort /var/run/$SLICENAME/pids.beforestart )`; do
-            echo "STILL RUNNING: " `ps ax | grep $pid | grep -v grep` 1>&2
-            kill -$signal $pid 2> /dev/null
-            KILLED="TRUE"
+            echo "STILL RUNNING: " $(ps $pid) 1>&2
+            if kill -$signal $pid 2> /dev/null ; then
+                KILLED="TRUE"
+            fi
         done
     fi
     echo $KILLED

--- a/slicebase/etc/mlab/slicectrl-functions
+++ b/slicebase/etc/mlab/slicectrl-functions
@@ -35,6 +35,7 @@ function start_before_everything () {
 }
 
 function stop_after_everything () {
+    sleep 1
     KILLED=$( kill_remaining TERM )
     if [ -n "$KILLED" ] ; then
         sleep 3
@@ -45,12 +46,12 @@ function stop_after_everything () {
 function kill_remaining () {
     local signal=$1
     KILLED=
-    pgrep -v -f "slicectrl|rsync|rpm" > /var/run/$SLICENAME/pids.afterstop
+    pgrep -v -f "slicectrl|rsync|rpm|bash|login|/bin/su" > /var/run/$SLICENAME/pids.afterstop
     if [ -f /var/run/$SLICENAME/pids.beforestart ] ; then
         for pid in `comm -23 <( sort /var/run/$SLICENAME/pids.afterstop ) \
-                             <( sort /var/run/$SLICENAME/pids.beforestart )`; do 
-            echo "STILL RUNNING: " `ps ax | grep $pid`
-            kill -$signal $pid
+                             <( sort /var/run/$SLICENAME/pids.beforestart )`; do
+            echo "STILL RUNNING: " `ps ax | grep $pid | grep -v grep` 1>&2
+            kill -$signal $pid 2> /dev/null
             KILLED="TRUE"
         done
     fi


### PR DESCRIPTION
This change modifies slice-update and slicectrl restart to allow remote operations more easily via ssh (and ansible).

Specifically, slice-update returns immediately and slicectrl restart does not kill the calling process during shutdown.