### PR TITLE
Use a Unix timestamp instead of a count of commits for tagging slice package releases.

### DIFF
--- a/slicetag.sh
+++ b/slicetag.sh
@@ -48,7 +48,7 @@ set -e
 command=$1
 shift || :
 
-TAG=$( git rev-list --all | wc -l ) 
+TAG=$( date -u +"%s" ) 
 
 if [[ $command =~ "get" ]] ; then
     # Expect a tag to have been set previously.

--- a/slicetag.sh
+++ b/slicetag.sh
@@ -48,7 +48,7 @@ set -e
 command=$1
 shift || :
 
-TAG=$( date -u +"%s" ) 
+TAG=$( git log -1 --format=%ct ) 
 
 if [[ $command =~ "get" ]] ; then
     # Expect a tag to have been set previously.


### PR DESCRIPTION
In the past we have tagged RPM slice releases based on the count of commits in the particular *-support repo for a slice (e.g., [ndt-support](https://github.com/m-lab/ndt-support)), which yielded RPM package names like 2.1.8-177.mlab, where 177 is the RPM package release (set in the package metadata as well a the filename).  This versioning method doesn't actually give you any obvious indication of when the package was built, and has caused problems when we build the slice package from different repositories (usually forks) which may actually contain different numbers of commits. Using a Unix timestamp should eliminate this issue of where the package is built by using a (hopefully) universal value (if ntp is doing its job), which also has the benefit of embedding information in the release and filename about when the package was built.