### PR TITLE
Adds a new slice utility named slice-canary

### DIFF
--- a/slicebase/bin/slice-canary
+++ b/slicebase/bin/slice-canary
@@ -36,8 +36,7 @@ cp -a /etc/$YUMREPOD /tmp/$CANARYREPOD
 # Modify the "canary" yum configuration to point to the "canary" repos
 # directory.  The variable substitution below simply replaces every instance of
 # '.' with '\.' in the variable $YUMREPOD.
-sed -i "s|/etc/${YUMREPOD//\./\\.}|/tmp/${CANARYREPOD}|" \
-    /tmp/$CANARYCONF
+sed -i "s|/etc/${YUMREPOD//\./\\.}|/tmp/${CANARYREPOD}|" /tmp/$CANARYCONF
 # Locate the [slicebase.centos] block, then change the URL path from production
 # to staging. The 'N;N;' syntax loads the next two lines after the pattern match
 # into the buffer, which should include the line containing the repo URL, so
@@ -63,7 +62,7 @@ fi
 OLDVER=$(rpm -q $SLICENAME)
 
 # Remove the existing slice package.
-echo "* Removing existing slice package."
+echo "* Removing existing slice package: ${OLDVER}"
 rpm --quiet -e $SLICENAME
 
 # Recursively remove /etc/mlab so that the preinstall script of the new slice
@@ -77,7 +76,7 @@ yum -q -y -c /tmp/$CANARYCONF install $SLICENAME > /dev/null
 
 if [ $? -eq 0 ]; then
     # Record the new version number of the slice package.
-	NEWVER=$(rpm -q $SLICENAME)
+    NEWVER=$(rpm -q $SLICENAME)
     service slicectrl start &> /dev/null
     echo "* Successfully upgraded from $OLDVER to $NEWVER."
     cleanup

--- a/slicebase/bin/slice-canary
+++ b/slicebase/bin/slice-canary
@@ -46,7 +46,7 @@ sed -i '/slicebase\.centos/ { N;N; s/production-centos6/staging-centos6/ }' \
 # metadata.
 echo "* Checking to see if an update is available in the staging repository."
 yum -q clean all
-yum -c /tmp/yum.canary.conf check-update $SLICENAME > /dev/null
+yum -c /tmp/${CANARYCONF} check-update $SLICENAME > /dev/null
 if [ $? -ne 100 ]; then
     echo "A newer version of slice package is not available."
     echo "Is a newer version installed in the staging yum repository?"

--- a/slicebase/bin/slice-canary
+++ b/slicebase/bin/slice-canary
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+YUMCONF="yum.conf"
+CANARYCONF="yum.canary.conf"
+YUMREPOD="yum.slice.d"
+CANARYREPOD="yum.canary.d"
+
+if [ -s /etc/slicename ]; then
+    SLICENAME=$(cat /etc/slicename)
+else
+    echo "Error: /etc/slicename is either empty or doesn't exist."
+    exit 1
+fi
+
+if [[ $EUID -ne 0 ]] ; then
+    echo "Error: please run slice-canary as root."
+    exit 1
+fi
+
+if ! service slicectrl stop &> /dev/null; then
+    echo "Error: slicectrl failed to stop all slice services."
+    exit 1
+fi
+
+# Function to clean up temporary yum configs
+function cleanup {
+    rm -rf /tmp/$CANARYCONF /tmp/$CANARYREPOD
+}
+
+# Copy the regular production yum configurations to new "canary" versions that
+# we can use to upgrade the slice without actually modifying the production
+# versions.
+cp /etc/$YUMCONF /tmp/$CANARYCONF
+cp -a /etc/$YUMREPOD /tmp/$CANARYREPOD
+
+# Modify the "canary" yum configurations to point to the M-Lab staging yum
+# repository.
+sed -i "s/\/etc\/${YUMREPOD//\./\\.}/\/tmp\/${CANARYREPOD//\./\\.}/" \
+    /tmp/$CANARYCONF
+sed -i '/slicebase\.centos/ { N;N; s/production-centos6/staging-centos6/ }' \
+    "/tmp/${CANARYREPOD}/slice.repo"
+
+# See if there is a newer version available before proceeding. It seems that
+# yum returns with code 100 when there is in fact an update available. We clean
+# all the cache files in advance to be sure that we're dealing with fresh
+# metadata.
+echo "* Checking to see if an update is available in the staging repository."
+yum -q clean all
+yum -c /tmp/yum.canary.conf check-update $SLICENAME > /dev/null
+if [ $? -ne 100 ]; then
+    echo "A newer version of slice package is not available."
+    echo "Is a newer version installed in the staging yum repository?"
+    cleanup
+    exit 1
+fi
+
+# Record the old version number of the slice package.
+OLDVER=$(yum list installed | grep $SLICENAME | awk '{print $2}')
+
+# Remove the existing slice package.
+echo "* Removing existing slice package."
+rpm --quiet -e $SLICENAME
+
+# Recursively remove /etc/mlab so that the preinstall script of the new slice
+# package doesn't think the slice is already installed and try to invoke
+# slice-update instead of just installing the new package.
+rm -rf /etc/mlab
+
+# Install new slice package
+echo "* Installing new slice package."
+yum -q -y -c /tmp/$CANARYCONF install $SLICENAME > /dev/null
+
+if [ $? -eq 0 ]; then
+    # Record the new version number of the slice package.
+    NEWVER=$(yum list installed | grep $SLICENAME | awk '{print $2}')
+    service slicectrl start &> /dev/null
+    echo "* Successfully upgraded from $OLDVER to $NEWVER."
+    cleanup
+else
+    echo "Error: installation of the updated slice package failed."
+    cleanup
+    exit 1
+fi

--- a/slicebase/bin/slice-canary
+++ b/slicebase/bin/slice-canary
@@ -33,8 +33,10 @@ function cleanup {
 cp /etc/$YUMCONF /tmp/$CANARYCONF
 cp -a /etc/$YUMREPOD /tmp/$CANARYREPOD
 
-# Modify the "canary" yum configuration to point to the "canary" repos directory
-sed -i "s/\/etc\/${YUMREPOD//\./\\.}/\/tmp\/${CANARYREPOD//\./\\.}/" \
+# Modify the "canary" yum configuration to point to the "canary" repos
+# directory.  The variable substitution below simply replaces every instance of
+# '.' with '\.' in the variable $YUMREPOD.
+sed -i "s|/etc/${YUMREPOD//\./\\.}|/tmp/${CANARYREPOD}|" \
     /tmp/$CANARYCONF
 # Locate the [slicebase.centos] block, then change the URL path from production
 # to staging. The 'N;N;' syntax loads the next two lines after the pattern match

--- a/slicebase/bin/slice-canary
+++ b/slicebase/bin/slice-canary
@@ -33,12 +33,15 @@ function cleanup {
 cp /etc/$YUMCONF /tmp/$CANARYCONF
 cp -a /etc/$YUMREPOD /tmp/$CANARYREPOD
 
-# Modify the "canary" yum configurations to point to the M-Lab staging yum
-# repository.
+# Modify the "canary" yum configuration to point to the "canary" repos directory
 sed -i "s/\/etc\/${YUMREPOD//\./\\.}/\/tmp\/${CANARYREPOD//\./\\.}/" \
     /tmp/$CANARYCONF
+# Locate the [slicebase.centos] block, then change the URL path from production
+# to staging. The 'N;N;' syntax loads the next two lines after the pattern match
+# into the buffer, which should include the line containing the repo URL, so
+# that the substitution pattern can operate on the URL.
 sed -i '/slicebase\.centos/ { N;N; s/production-centos6/staging-centos6/ }' \
-    "/tmp/${CANARYREPOD}/slice.repo"
+    /tmp/${CANARYREPOD}/slice.repo
 
 # See if there is a newer version available before proceeding. It seems that
 # yum returns with code 100 when there is in fact an update available. We clean

--- a/slicebase/bin/slice-canary
+++ b/slicebase/bin/slice-canary
@@ -58,7 +58,7 @@ if [ $? -ne 100 ]; then
 fi
 
 # Record the old version number of the slice package.
-OLDVER=$(yum list installed | grep $SLICENAME | awk '{print $2}')
+OLDVER=$(rpm -q $SLICENAME)
 
 # Remove the existing slice package.
 echo "* Removing existing slice package."
@@ -75,7 +75,7 @@ yum -q -y -c /tmp/$CANARYCONF install $SLICENAME > /dev/null
 
 if [ $? -eq 0 ]; then
     # Record the new version number of the slice package.
-    NEWVER=$(yum list installed | grep $SLICENAME | awk '{print $2}')
+	NEWVER=$(rpm -q $SLICENAME)
     service slicectrl start &> /dev/null
     echo "* Successfully upgraded from $OLDVER to $NEWVER."
     cleanup


### PR DESCRIPTION
In the rollout of a new slice package we like to go from testing -> staging -> production.  However, before committing 100% to a complete production rollout, we would like to install the version in staging on a select few production nodes to be sure that nothing unexpected happens. Previously, there was no standard way of going about this, which could lead to undesirable results.  This PR adds a new slice-canary utility, which, when run, essentially copies the slice's yum configurations, alters them to point to staging, then tells yum to use those modified configs to install the version in staging.