### PR TITLE
Call the %attrs macro with slice-canary

### DIFF
--- a/generic-slice.m4.spec
+++ b/generic-slice.m4.spec
@@ -87,6 +87,7 @@ rm -rf $RPM_BUILD_ROOT
 %attr(0755,root,root) /etc/init.d/rsyncd 
 %attr(0755,root,root) /usr/bin/slice-update
 %attr(0755,root,root) /usr/bin/slice-restart
+%attr(0755,root,root) /usr/bin/slice-canary
 
 # NOTE: this is an m4 macro to include extra files
 include(SLICEfiles)


### PR DESCRIPTION
Not doing so will lead to the file being installed, but not listed in
the files of the package this error is thrown:

RPM build errors:
   Installed (but unpackaged) file(s) found:
   /usr/bin/slice-canary