### PR TITLE
Tool to generate rsyncd configuration.

### DIFF
--- a/slicetag.sh
+++ b/slicetag.sh
@@ -55,8 +55,8 @@ if [[ $command =~ "get" ]] ; then
     # Expect a tag to have been set previously.
     RELEASE=$( git describe --abbrev=0 --tags 2> /dev/null || : )
     if [ -z "$RELEASE" ] || on_master ; then
-        # But, if there is not one, return 'master'
-        RELEASE=master-$TAG.mlab
+        # But, if there is not one, return the last-commit date tag as version.
+        RELEASE=$TAG-0.mlab
     fi
     echo $RELEASE
 elif [[ $command =~ "set" ]] ; then


### PR DESCRIPTION
Given the dysfunctional state of rsyncd configuration for M-Lab slices, this tool attempts to unify the mechanism that experiments use.

The idea would be to run this script from the slice `initialize.sh` script. However, I've not yet determined if the order of operations is correct for:
- install slice package
- generate rsyncd.conf
- start rsyncd
- start slice

But, this can be worked out.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/package/14)

<!-- Reviewable:end -->