### PR TITLE
Use the last commit timestamp as the rpm release if there is no tag

### DIFF
--- a/slicetag.sh
+++ b/slicetag.sh
@@ -55,8 +55,8 @@ if [[ $command =~ "get" ]] ; then
     # Expect a tag to have been set previously.
     RELEASE=$( git describe --abbrev=0 --tags 2> /dev/null || : )
     if [ -z "$RELEASE" ] || on_master ; then
-        # But, if there is not one, return 'master'
-        RELEASE=master-$TAG.mlab
+        # But, if there is not one, return the last-commit date tag as version.
+        RELEASE=$TAG-0.mlab
     fi
     echo $RELEASE
 elif [[ $command =~ "set" ]] ; then


### PR DESCRIPTION
To support simpler build automation of RPM packages, this change generates a default "release" string that uses the "last commit timestamp" as the version.

These versions will supersede the manually tagged versions used in the past. Versions like 201710211030 are interpreted as large numbers and will be ordered before legacy version numbers, so during deployment, yum will continue to do the right thing for upgrades.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/package/18)
<!-- Reviewable:end -->
